### PR TITLE
Update LICENSE to have Lusty-Lobster as copyrighter

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2015 determinedWaffle
+Copyright (c) 2015 Lusty-Lobster
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
Changed copyrighter to be Lusty-Lobster in order to improve clarity, and prevent legal issues.
